### PR TITLE
Actualize PacketDiag example with TCP packet spec

### DIFF
--- a/examples.html
+++ b/examples.html
@@ -674,7 +674,9 @@
   32-63: Sequence Number;
   64-95: Acknowledgment Number;
   96-99: Data Offset;
-  100-105: Reserved;
+  100-103: Reserved;
+  104: CWR [rotate = 270];
+  105: ECE [rotate = 270];
   106: URG [rotate = 270];
   107: ACK [rotate = 270];
   108: PSH [rotate = 270];
@@ -689,9 +691,9 @@
 }</code></pre>
 
             <div class="highlight">
-                <pre><code class="language-http">GET https://kroki.io/packetdiag/svg/eNptkU9Pg0AQxe9-ijnqYRN2QSgYD6bGPzFpCW1jTGPMyk5hQ9mtsMjB-N0dIGk8cH2_mXkzb04yr9ApLQv4uQDI7bHXypVwC764IcFYhR8l6qJ0pEWkkegxfp3AxnZNjpDaxg2VPGQ-T-AeW6eNdNqaM_IFC31qwK8ODbWsuvoTm4GEAYtp1F1eGdsfURU1GvePxyGLYxoqnYT14dDiZOXRBh71Zdhi841qEsMEdtkj7BvrpENaV0Te-4Qi8li-zKJFAunmaRaRc7bZziHu0Tlvq1lEITw8zyPBuKBVXrVRth8lsWA8oGyWJeZV29WjGAQUMJnvmmKII7XauCkPHtLlMTlcrk9DxC1IoyCVSmlTXI0VsWBC0EQ1ZLanh56_59MWv39OCoi9</code></pre>
+                <pre><code class="language-http">GET https://kroki.io/packetdiag/svg/eNptkstOwzAQRfd8xSxhYSl2QtoEsUChPITURilVhSqETDxNrLZ2SRy6QPw7k0SqWHh7zzyu7_goyx06pWUFPxcApd2ftHI13EIobkgwVuFHjbqqHWkT0kgMGL9OYWm7pkTIbeP6Sh6zkKdwj63TRjptzRmFgsUhNeBXh4Za5t3hE5uexBFLaNRduTP2tEdVHdC4fzyJWZLQUOkkLLbbFsdVATkIaGKBLTbfqEYxSiFbF7BprJMOya6YBO8joh2zbOZFcQqr4tGLJuQse_GiaQr58smLyG-xfPUhHlAIb3Mvougenv1IMC7IylobZU-DJKaMR_T-rMZy13aHQYwiOgstXzVVH2JutXFjijymvBLacLk49odpQRoFuVRKm-pqqEgEE4Imqj7pDX2D881DcvH7B-DBllc=</code></pre>
                 <button class="button is-small bd-copy"
-                        data-clipboard-text="https://kroki.io/packetdiag/svg/eNptkU9Pg0AQxe9-ijnqYRN2QSgYD6bGPzFpCW1jTGPMyk5hQ9mtsMjB-N0dIGk8cH2_mXkzb04yr9ApLQv4uQDI7bHXypVwC764IcFYhR8l6qJ0pEWkkegxfp3AxnZNjpDaxg2VPGQ-T-AeW6eNdNqaM_IFC31qwK8ODbWsuvoTm4GEAYtp1F1eGdsfURU1GvePxyGLYxoqnYT14dDiZOXRBh71Zdhi841qEsMEdtkj7BvrpENaV0Te-4Qi8li-zKJFAunmaRaRc7bZziHu0Tlvq1lEITw8zyPBuKBVXrVRth8lsWA8oGyWJeZV29WjGAQUMJnvmmKII7XauCkPHtLlMTlcrk9DxC1IoyCVSmlTXI0VsWBC0EQ1ZLanh56_59MWv39OCoi9"
+                        data-clipboard-text="https://kroki.io/packetdiag/svg/eNptkstOwzAQRfd8xSxhYSl2QtoEsUChPITURilVhSqETDxNrLZ2SRy6QPw7k0SqWHh7zzyu7_goyx06pWUFPxcApd2ftHI13EIobkgwVuFHjbqqHWkT0kgMGL9OYWm7pkTIbeP6Sh6zkKdwj63TRjptzRmFgsUhNeBXh4Za5t3hE5uexBFLaNRduTP2tEdVHdC4fzyJWZLQUOkkLLbbFsdVATkIaGKBLTbfqEYxSiFbF7BprJMOya6YBO8joh2zbOZFcQqr4tGLJuQse_GiaQr58smLyG-xfPUhHlAIb3Mvougenv1IMC7IylobZU-DJKaMR_T-rMZy13aHQYwiOgstXzVVH2JutXFjijymvBLacLk49odpQRoFuVRKm-pqqEgEE4Imqj7pDX2D881DcvH7B-DBllc="
                         title="Copy to clipboard">
                     <svg fill="currentColor" viewBox="0 0 896 1024" xmlns="http://www.w3.org/2000/svg">
                         <path d="M128 768h256v64H128v-64z m320-384H128v64h320v-64z m128 192V448L384 640l192 192V704h320V576H576z m-288-64H128v64h160v-64zM128 704h160v-64H128v64z m576 64h64v128c-1 18-7 33-19 45s-27 18-45 19H64c-35 0-64-29-64-64V192c0-35 29-64 64-64h192C256 57 313 0 384 0s128 57 128 128h192c35 0 64 29 64 64v320h-64V320H64v576h640V768zM128 256h512c0-35-29-64-64-64h-64c-35 0-64-29-64-64s-29-64-64-64-64 29-64 64-29 64-64 64h-64c-35 0-64 29-64 64z"></path>
@@ -706,386 +708,177 @@
                         <feGaussianBlur id="feGaussianBlur3780" stdDeviation="4.2"/>
                     </filter>
                 </defs>
-                <title>packetdiag</title>
-                <desc>packetdiag { colwidth = 32; node_height = 72; 0-15: Source Port; 16-31: Destination Port; 32-63: Sequence Number; 64-95: Acknowledgment Number; 96-99: Data
-                    Offset; 100-105: Reserved; 106: URG [rotate = 270]; 107: ACK [rotate = 270]; 108: PSH [rotate = 270]; 109: RST [rotate = 270]; 110: SYN [rotate = 270]; 111: FIN
-                    [rotate = 270]; 112-127: Window; 128-143: Checksum; 144-159: Urgent Pointer; 160-191: (Options and Padding); 192-223: data [colheight = 3];}
-                </desc>
-                <path d="M 64 48 L 64 80" fill="none" stroke="rgb(0,0,0)"/>
-                <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="7" x="64.5" y="42">0
-                </text>
-                <path d="M 88 64 L 88 80" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 112 64 L 112 80" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 136 64 L 136 80" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 160 64 L 160 80" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 184 64 L 184 80" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 208 64 L 208 80" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 232 64 L 232 80" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 256 48 L 256 80" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 280 64 L 280 80" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 304 64 L 304 80" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 328 64 L 328 80" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 352 64 L 352 80" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 376 64 L 376 80" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 400 64 L 400 80" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 424 64 L 424 80" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 448 48 L 448 80" fill="none" stroke="rgb(0,0,0)"/>
-                <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="13" x="448.5" y="42">16
-                </text>
-                <path d="M 472 64 L 472 80" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 496 64 L 496 80" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 520 64 L 520 80" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 544 64 L 544 80" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 568 64 L 568 80" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 592 64 L 592 80" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 616 64 L 616 80" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 640 48 L 640 80" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 664 64 L 664 80" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 688 64 L 688 80" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 712 64 L 712 80" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 736 64 L 736 80" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 760 64 L 760 80" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 784 64 L 784 80" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 808 64 L 808 80" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 832 48 L 832 80" fill="none" stroke="rgb(0,0,0)"/>
-                <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="13" x="832.5" y="42">32
-                </text>
-                <rect fill="rgb(255,255,255)" height="72" stroke="rgb(255,255,255)" width="384" x="64" y="80"/>
-                <path d="M 64 80 L 448 80" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 448 80 L 448 152" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 448 152 L 64 152" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 64 152 L 64 80" fill="none" stroke="rgb(0,0,0)"/>
-                <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="67" x="256.5" y="122">
-                    Source Port
-                </text>
-                <rect fill="rgb(255,255,255)" height="72" stroke="rgb(255,255,255)" width="384" x="448" y="80"/>
-                <path d="M 448 80 L 832 80" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 832 80 L 832 152" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 832 152 L 448 152" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 448 152 L 448 80" fill="none" stroke="rgb(0,0,0)"/>
-                <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="97" x="640.5" y="122">
-                    Destination Port
-                </text>
-                <rect fill="rgb(255,255,255)" height="72" stroke="rgb(255,255,255)" width="768" x="64" y="152"/>
-                <path d="M 64 152 L 832 152" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 832 152 L 832 224" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 832 224 L 64 224" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 64 224 L 64 152" fill="none" stroke="rgb(0,0,0)"/>
-                <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="91" x="448.5" y="194">
-                    Sequence Number
-                </text>
-                <rect fill="rgb(255,255,255)" height="72" stroke="rgb(255,255,255)" width="768" x="64" y="224"/>
-                <path d="M 64 224 L 832 224" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 832 224 L 832 296" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 832 296 L 64 296" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 64 296 L 64 224" fill="none" stroke="rgb(0,0,0)"/>
-                <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="128" x="448.0" y="266">
-                    Acknowledgment Number
-                </text>
-                <rect fill="rgb(255,255,255)" height="72" stroke="rgb(255,255,255)" width="96" x="64" y="296"/>
-                <path d="M 64 296 L 160 296" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 160 296 L 160 368" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 160 368 L 64 368" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 64 368 L 64 296" fill="none" stroke="rgb(0,0,0)"/>
-                <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="67" x="112.5" y="338">Data
-                    Offset
-                </text>
-                <rect fill="rgb(255,255,255)" height="72" stroke="rgb(255,255,255)" width="144" x="160" y="296"/>
-                <path d="M 160 296 L 304 296" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 304 296 L 304 368" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 304 368 L 160 368" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 160 368 L 160 296" fill="none" stroke="rgb(0,0,0)"/>
-                <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="49" x="232.5" y="338">
-                    Reserved
-                </text>
-                <rect fill="rgb(255,255,255)" height="72" stroke="rgb(255,255,255)" width="24" x="304" y="296"/>
-                <path d="M 304 296 L 328 296" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 328 296 L 328 368" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 328 368 L 304 368" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 304 368 L 304 296" fill="none" stroke="rgb(0,0,0)"/>
+                <title>blockdiag</title>
+                <desc>packetdiag {colwidth = 32; node_height = 72; 0-15: Source Port; 16-31: Destination Port; 32-63: Sequence Number; 64-95: Acknowledgment Number; 96-99: Data
+                    Offset; 100-103: Reserved; 104: CWR [rotate = 270]; 105: ECE [rotate = 270]; 106: URG [rotate = 270]; 107: ACK [rotate = 270]; 108: PSH [rotate = 270]; 109: RST [rotate = 270]; 110: SYN [rotate = 270]; 111: FIN
+                    [rotate = 270]; 112-127: Window; 128-143: Checksum; 144-159: Urgent Pointer; 160-191: (Options and Padding); 192-223: data [colheight = 3];}</desc>
+                <path d="M 64 48 L 64 80" fill="none" stroke="rgb(0,0,0)" />
+                <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="7" x="64.5" y="42">0</text>
+                <path d="M 88 64 L 88 80" fill="none" stroke="rgb(0,0,0)" />
+                <path d="M 112 64 L 112 80" fill="none" stroke="rgb(0,0,0)" />
+                <path d="M 136 64 L 136 80" fill="none" stroke="rgb(0,0,0)" />
+                <path d="M 160 64 L 160 80" fill="none" stroke="rgb(0,0,0)" />
+                <path d="M 184 64 L 184 80" fill="none" stroke="rgb(0,0,0)" />
+                <path d="M 208 64 L 208 80" fill="none" stroke="rgb(0,0,0)" />
+                <path d="M 232 64 L 232 80" fill="none" stroke="rgb(0,0,0)" />
+                <path d="M 256 48 L 256 80" fill="none" stroke="rgb(0,0,0)" />
+                <path d="M 280 64 L 280 80" fill="none" stroke="rgb(0,0,0)" />
+                <path d="M 304 64 L 304 80" fill="none" stroke="rgb(0,0,0)" />
+                <path d="M 328 64 L 328 80" fill="none" stroke="rgb(0,0,0)" />
+                <path d="M 352 64 L 352 80" fill="none" stroke="rgb(0,0,0)" />
+                <path d="M 376 64 L 376 80" fill="none" stroke="rgb(0,0,0)" />
+                <path d="M 400 64 L 400 80" fill="none" stroke="rgb(0,0,0)" />
+                <path d="M 424 64 L 424 80" fill="none" stroke="rgb(0,0,0)" />
+                <path d="M 448 48 L 448 80" fill="none" stroke="rgb(0,0,0)" />
+                <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="14" x="448.0" y="42">16</text>
+                <path d="M 472 64 L 472 80" fill="none" stroke="rgb(0,0,0)" />
+                <path d="M 496 64 L 496 80" fill="none" stroke="rgb(0,0,0)" />
+                <path d="M 520 64 L 520 80" fill="none" stroke="rgb(0,0,0)" />
+                <path d="M 544 64 L 544 80" fill="none" stroke="rgb(0,0,0)" />
+                <path d="M 568 64 L 568 80" fill="none" stroke="rgb(0,0,0)" />
+                <path d="M 592 64 L 592 80" fill="none" stroke="rgb(0,0,0)" />
+                <path d="M 616 64 L 616 80" fill="none" stroke="rgb(0,0,0)" />
+                <path d="M 640 48 L 640 80" fill="none" stroke="rgb(0,0,0)" />
+                <path d="M 664 64 L 664 80" fill="none" stroke="rgb(0,0,0)" />
+                <path d="M 688 64 L 688 80" fill="none" stroke="rgb(0,0,0)" />
+                <path d="M 712 64 L 712 80" fill="none" stroke="rgb(0,0,0)" />
+                <path d="M 736 64 L 736 80" fill="none" stroke="rgb(0,0,0)" />
+                <path d="M 760 64 L 760 80" fill="none" stroke="rgb(0,0,0)" />
+                <path d="M 784 64 L 784 80" fill="none" stroke="rgb(0,0,0)" />
+                <path d="M 808 64 L 808 80" fill="none" stroke="rgb(0,0,0)" />
+                <path d="M 832 48 L 832 80" fill="none" stroke="rgb(0,0,0)" />
+                <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="14" x="832.0" y="42">32</text>
+                <rect fill="rgb(255,255,255)" height="72" stroke="rgb(255,255,255)" width="384" x="64" y="80" />
+                <path d="M 64 80 L 448 80" fill="none" stroke="rgb(0,0,0)" />
+                <path d="M 448 80 L 448 152" fill="none" stroke="rgb(0,0,0)" />
+                <path d="M 448 152 L 64 152" fill="none" stroke="rgb(0,0,0)" />
+                <path d="M 64 152 L 64 80" fill="none" stroke="rgb(0,0,0)" />
+                <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="67" x="256.5" y="122">Source Port</text>
+                <rect fill="rgb(255,255,255)" height="72" stroke="rgb(255,255,255)" width="384" x="448" y="80" />
+                <path d="M 448 80 L 832 80" fill="none" stroke="rgb(0,0,0)" />
+                <path d="M 832 80 L 832 152" fill="none" stroke="rgb(0,0,0)" />
+                <path d="M 832 152 L 448 152" fill="none" stroke="rgb(0,0,0)" />
+                <path d="M 448 152 L 448 80" fill="none" stroke="rgb(0,0,0)" />
+                <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="92" x="640.0" y="122">Destination Port</text>
+                <rect fill="rgb(255,255,255)" height="72" stroke="rgb(255,255,255)" width="768" x="64" y="152" />
+                <path d="M 64 152 L 832 152" fill="none" stroke="rgb(0,0,0)" />
+                <path d="M 832 152 L 832 224" fill="none" stroke="rgb(0,0,0)" />
+                <path d="M 832 224 L 64 224" fill="none" stroke="rgb(0,0,0)" />
+                <path d="M 64 224 L 64 152" fill="none" stroke="rgb(0,0,0)" />
+                <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="105" x="448.5" y="195">Sequence Number</text>
+                <rect fill="rgb(255,255,255)" height="72" stroke="rgb(255,255,255)" width="768" x="64" y="224" />
+                <path d="M 64 224 L 832 224" fill="none" stroke="rgb(0,0,0)" />
+                <path d="M 832 224 L 832 296" fill="none" stroke="rgb(0,0,0)" />
+                <path d="M 832 296 L 64 296" fill="none" stroke="rgb(0,0,0)" />
+                <path d="M 64 296 L 64 224" fill="none" stroke="rgb(0,0,0)" />
+                <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="148" x="448.0" y="267">Acknowledgment Number</text>
+                <rect fill="rgb(255,255,255)" height="72" stroke="rgb(255,255,255)" width="96" x="64" y="296" />
+                <path d="M 64 296 L 160 296" fill="none" stroke="rgb(0,0,0)" />
+                <path d="M 160 296 L 160 368" fill="none" stroke="rgb(0,0,0)" />
+                <path d="M 160 368 L 64 368" fill="none" stroke="rgb(0,0,0)" />
+                <path d="M 64 368 L 64 296" fill="none" stroke="rgb(0,0,0)" />
+                <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="64" x="112.0" y="338">Data Offset</text>
+                <rect fill="rgb(255,255,255)" height="72" stroke="rgb(255,255,255)" width="96" x="160" y="296" />
+                <path d="M 160 296 L 256 296" fill="none" stroke="rgb(0,0,0)" />
+                <path d="M 256 296 L 256 368" fill="none" stroke="rgb(0,0,0)" />
+                <path d="M 256 368 L 160 368" fill="none" stroke="rgb(0,0,0)" />
+                <path d="M 160 368 L 160 296" fill="none" stroke="rgb(0,0,0)" />
+                <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="52" x="208.0" y="338">Reserved</text>
+                <rect fill="rgb(255,255,255)" height="72" stroke="rgb(255,255,255)" width="24" x="256" y="296" />
+                <path d="M 256 296 L 280 296" fill="none" stroke="rgb(0,0,0)" />
+                <path d="M 280 296 L 280 368" fill="none" stroke="rgb(0,0,0)" />
+                <path d="M 280 368 L 256 368" fill="none" stroke="rgb(0,0,0)" />
+                <path d="M 256 368 L 256 296" fill="none" stroke="rgb(0,0,0)" />
+                <g transform="rotate(270,256,368)">
+                    <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="29" x="292.5" y="386">CWR</text>
+                </g>
+                <rect fill="rgb(255,255,255)" height="72" stroke="rgb(255,255,255)" width="24" x="280" y="296" />
+                <path d="M 280 296 L 304 296" fill="none" stroke="rgb(0,0,0)" />
+                <path d="M 304 296 L 304 368" fill="none" stroke="rgb(0,0,0)" />
+                <path d="M 304 368 L 280 368" fill="none" stroke="rgb(0,0,0)" />
+                <path d="M 280 368 L 280 296" fill="none" stroke="rgb(0,0,0)" />
+                <g transform="rotate(270,280,368)">
+                    <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="24" x="316.0" y="386">ECE</text>
+                </g>
+                <rect fill="rgb(255,255,255)" height="72" stroke="rgb(255,255,255)" width="24" x="304" y="296" />
+                <path d="M 304 296 L 328 296" fill="none" stroke="rgb(0,0,0)" />
+                <path d="M 328 296 L 328 368" fill="none" stroke="rgb(0,0,0)" />
+                <path d="M 328 368 L 304 368" fill="none" stroke="rgb(0,0,0)" />
+                <path d="M 304 368 L 304 296" fill="none" stroke="rgb(0,0,0)" />
                 <g transform="rotate(270,304,368)">
-                    <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="19" x="340.5" y="386">
-                        URG
-                    </text>
+                    <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="26" x="340.0" y="386">URG</text>
                 </g>
-                <rect fill="rgb(255,255,255)" height="72" stroke="rgb(255,255,255)" width="24" x="328" y="296"/>
-                <path d="M 328 296 L 352 296" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 352 296 L 352 368" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 352 368 L 328 368" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 328 368 L 328 296" fill="none" stroke="rgb(0,0,0)"/>
+                <rect fill="rgb(255,255,255)" height="72" stroke="rgb(255,255,255)" width="24" x="328" y="296" />
+                <path d="M 328 296 L 352 296" fill="none" stroke="rgb(0,0,0)" />
+                <path d="M 352 296 L 352 368" fill="none" stroke="rgb(0,0,0)" />
+                <path d="M 352 368 L 328 368" fill="none" stroke="rgb(0,0,0)" />
+                <path d="M 328 368 L 328 296" fill="none" stroke="rgb(0,0,0)" />
                 <g transform="rotate(270,328,368)">
-                    <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="19" x="364.5" y="386">
-                        ACK
-                    </text>
+                    <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="26" x="364.0" y="386">ACK</text>
                 </g>
-                <rect fill="rgb(255,255,255)" height="72" stroke="rgb(255,255,255)" width="24" x="352" y="296"/>
-                <path d="M 352 296 L 376 296" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 376 296 L 376 368" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 376 368 L 352 368" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 352 368 L 352 296" fill="none" stroke="rgb(0,0,0)"/>
+                <rect fill="rgb(255,255,255)" height="72" stroke="rgb(255,255,255)" width="24" x="352" y="296" />
+                <path d="M 352 296 L 376 296" fill="none" stroke="rgb(0,0,0)" />
+                <path d="M 376 296 L 376 368" fill="none" stroke="rgb(0,0,0)" />
+                <path d="M 376 368 L 352 368" fill="none" stroke="rgb(0,0,0)" />
+                <path d="M 352 368 L 352 296" fill="none" stroke="rgb(0,0,0)" />
                 <g transform="rotate(270,352,368)">
-                    <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="19" x="388.5" y="386">
-                        PSH
-                    </text>
+                    <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="25" x="388.5" y="386">PSH</text>
                 </g>
-                <rect fill="rgb(255,255,255)" height="72" stroke="rgb(255,255,255)" width="24" x="376" y="296"/>
-                <path d="M 376 296 L 400 296" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 400 296 L 400 368" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 400 368 L 376 368" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 376 368 L 376 296" fill="none" stroke="rgb(0,0,0)"/>
+                <rect fill="rgb(255,255,255)" height="72" stroke="rgb(255,255,255)" width="24" x="376" y="296" />
+                <path d="M 376 296 L 400 296" fill="none" stroke="rgb(0,0,0)" />
+                <path d="M 400 296 L 400 368" fill="none" stroke="rgb(0,0,0)" />
+                <path d="M 400 368 L 376 368" fill="none" stroke="rgb(0,0,0)" />
+                <path d="M 376 368 L 376 296" fill="none" stroke="rgb(0,0,0)" />
                 <g transform="rotate(270,376,368)">
-                    <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="19" x="412.5" y="386">
-                        RST
-                    </text>
+                    <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="24" x="412.0" y="386">RST</text>
                 </g>
-                <rect fill="rgb(255,255,255)" height="72" stroke="rgb(255,255,255)" width="24" x="400" y="296"/>
-                <path d="M 400 296 L 424 296" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 424 296 L 424 368" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 424 368 L 400 368" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 400 368 L 400 296" fill="none" stroke="rgb(0,0,0)"/>
+                <rect fill="rgb(255,255,255)" height="72" stroke="rgb(255,255,255)" width="24" x="400" y="296" />
+                <path d="M 400 296 L 424 296" fill="none" stroke="rgb(0,0,0)" />
+                <path d="M 424 296 L 424 368" fill="none" stroke="rgb(0,0,0)" />
+                <path d="M 424 368 L 400 368" fill="none" stroke="rgb(0,0,0)" />
+                <path d="M 400 368 L 400 296" fill="none" stroke="rgb(0,0,0)" />
                 <g transform="rotate(270,400,368)">
-                    <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="19" x="436.5" y="386">
-                        SYN
-                    </text>
+                    <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="25" x="436.5" y="386">SYN</text>
                 </g>
-                <rect fill="rgb(255,255,255)" height="72" stroke="rgb(255,255,255)" width="24" x="424" y="296"/>
-                <path d="M 424 296 L 448 296" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 448 296 L 448 368" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 448 368 L 424 368" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 424 368 L 424 296" fill="none" stroke="rgb(0,0,0)"/>
+                <rect fill="rgb(255,255,255)" height="72" stroke="rgb(255,255,255)" width="24" x="424" y="296" />
+                <path d="M 424 296 L 448 296" fill="none" stroke="rgb(0,0,0)" />
+                <path d="M 448 296 L 448 368" fill="none" stroke="rgb(0,0,0)" />
+                <path d="M 448 368 L 424 368" fill="none" stroke="rgb(0,0,0)" />
+                <path d="M 424 368 L 424 296" fill="none" stroke="rgb(0,0,0)" />
                 <g transform="rotate(270,424,368)">
-                    <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="19" x="460.5" y="386">
-                        FIN
-                    </text>
+                    <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="22" x="460.0" y="386">FIN</text>
                 </g>
-                <rect fill="rgb(255,255,255)" height="72" stroke="rgb(255,255,255)" width="384" x="448" y="296"/>
-                <path d="M 448 296 L 832 296" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 832 296 L 832 368" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 832 368 L 448 368" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 448 368 L 448 296" fill="none" stroke="rgb(0,0,0)"/>
-                <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="37" x="640.5" y="338">
-                    Window
-                </text>
-                <rect fill="rgb(255,255,255)" height="72" stroke="rgb(255,255,255)" width="384" x="64" y="368"/>
-                <path d="M 64 368 L 448 368" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 448 368 L 448 440" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 448 440 L 64 440" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 64 440 L 64 368" fill="none" stroke="rgb(0,0,0)"/>
-                <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="49" x="256.5" y="410">
-                    Checksum
-                </text>
-                <rect fill="rgb(255,255,255)" height="72" stroke="rgb(255,255,255)" width="384" x="448" y="368"/>
-                <path d="M 448 368 L 832 368" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 832 368 L 832 440" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 832 440 L 448 440" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 448 440 L 448 368" fill="none" stroke="rgb(0,0,0)"/>
-                <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="85" x="640.5" y="410">
-                    Urgent Pointer
-                </text>
-                <rect fill="rgb(255,255,255)" height="72" stroke="rgb(255,255,255)" width="768" x="64" y="440"/>
-                <path d="M 64 440 L 832 440" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 832 440 L 832 512" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 832 512 L 64 512" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 64 512 L 64 440" fill="none" stroke="rgb(0,0,0)"/>
-                <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="128" x="448.0" y="482">
-                    (Options and Padding)
-                </text>
-                <rect fill="rgb(255,255,255)" height="216" stroke="rgb(255,255,255)" width="768" x="64" y="512"/>
-                <path d="M 64 512 L 832 512" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 832 512 L 832 728" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 832 728 L 64 728" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 64 728 L 64 512" fill="none" stroke="rgb(0,0,0)"/>
-                <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="25" x="448.5" y="626">
-                    data
-                </text>
-                <path d="M 64 48 L 64 80" fill="none" stroke="rgb(0,0,0)"/>
-                <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="7" x="64.5" y="42">0
-                </text>
-                <path d="M 88 64 L 88 80" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 112 64 L 112 80" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 136 64 L 136 80" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 160 64 L 160 80" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 184 64 L 184 80" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 208 64 L 208 80" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 232 64 L 232 80" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 256 48 L 256 80" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 280 64 L 280 80" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 304 64 L 304 80" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 328 64 L 328 80" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 352 64 L 352 80" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 376 64 L 376 80" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 400 64 L 400 80" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 424 64 L 424 80" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 448 48 L 448 80" fill="none" stroke="rgb(0,0,0)"/>
-                <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="13" x="448.5" y="42">16
-                </text>
-                <path d="M 472 64 L 472 80" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 496 64 L 496 80" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 520 64 L 520 80" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 544 64 L 544 80" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 568 64 L 568 80" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 592 64 L 592 80" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 616 64 L 616 80" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 640 48 L 640 80" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 664 64 L 664 80" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 688 64 L 688 80" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 712 64 L 712 80" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 736 64 L 736 80" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 760 64 L 760 80" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 784 64 L 784 80" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 808 64 L 808 80" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 832 48 L 832 80" fill="none" stroke="rgb(0,0,0)"/>
-                <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="13" x="832.5" y="42">32
-                </text>
-                <rect fill="rgb(255,255,255)" height="72" stroke="rgb(255,255,255)" width="384" x="64" y="80"/>
-                <path d="M 64 80 L 448 80" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 448 80 L 448 152" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 448 152 L 64 152" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 64 152 L 64 80" fill="none" stroke="rgb(0,0,0)"/>
-                <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="67" x="256.5" y="122">
-                    Source Port
-                </text>
-                <rect fill="rgb(255,255,255)" height="72" stroke="rgb(255,255,255)" width="384" x="448" y="80"/>
-                <path d="M 448 80 L 832 80" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 832 80 L 832 152" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 832 152 L 448 152" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 448 152 L 448 80" fill="none" stroke="rgb(0,0,0)"/>
-                <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="97" x="640.5" y="122">
-                    Destination Port
-                </text>
-                <rect fill="rgb(255,255,255)" height="72" stroke="rgb(255,255,255)" width="768" x="64" y="152"/>
-                <path d="M 64 152 L 832 152" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 832 152 L 832 224" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 832 224 L 64 224" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 64 224 L 64 152" fill="none" stroke="rgb(0,0,0)"/>
-                <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="91" x="448.5" y="194">
-                    Sequence Number
-                </text>
-                <rect fill="rgb(255,255,255)" height="72" stroke="rgb(255,255,255)" width="768" x="64" y="224"/>
-                <path d="M 64 224 L 832 224" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 832 224 L 832 296" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 832 296 L 64 296" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 64 296 L 64 224" fill="none" stroke="rgb(0,0,0)"/>
-                <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="128" x="448.0" y="266">
-                    Acknowledgment Number
-                </text>
-                <rect fill="rgb(255,255,255)" height="72" stroke="rgb(255,255,255)" width="96" x="64" y="296"/>
-                <path d="M 64 296 L 160 296" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 160 296 L 160 368" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 160 368 L 64 368" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 64 368 L 64 296" fill="none" stroke="rgb(0,0,0)"/>
-                <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="67" x="112.5" y="338">Data
-                    Offset
-                </text>
-                <rect fill="rgb(255,255,255)" height="72" stroke="rgb(255,255,255)" width="144" x="160" y="296"/>
-                <path d="M 160 296 L 304 296" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 304 296 L 304 368" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 304 368 L 160 368" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 160 368 L 160 296" fill="none" stroke="rgb(0,0,0)"/>
-                <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="49" x="232.5" y="338">
-                    Reserved
-                </text>
-                <rect fill="rgb(255,255,255)" height="72" stroke="rgb(255,255,255)" width="24" x="304" y="296"/>
-                <path d="M 304 296 L 328 296" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 328 296 L 328 368" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 328 368 L 304 368" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 304 368 L 304 296" fill="none" stroke="rgb(0,0,0)"/>
-                <g transform="rotate(270,304,368)">
-                    <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="19" x="340.5" y="386">
-                        URG
-                    </text>
-                </g>
-                <rect fill="rgb(255,255,255)" height="72" stroke="rgb(255,255,255)" width="24" x="328" y="296"/>
-                <path d="M 328 296 L 352 296" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 352 296 L 352 368" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 352 368 L 328 368" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 328 368 L 328 296" fill="none" stroke="rgb(0,0,0)"/>
-                <g transform="rotate(270,328,368)">
-                    <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="19" x="364.5" y="386">
-                        ACK
-                    </text>
-                </g>
-                <rect fill="rgb(255,255,255)" height="72" stroke="rgb(255,255,255)" width="24" x="352" y="296"/>
-                <path d="M 352 296 L 376 296" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 376 296 L 376 368" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 376 368 L 352 368" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 352 368 L 352 296" fill="none" stroke="rgb(0,0,0)"/>
-                <g transform="rotate(270,352,368)">
-                    <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="19" x="388.5" y="386">
-                        PSH
-                    </text>
-                </g>
-                <rect fill="rgb(255,255,255)" height="72" stroke="rgb(255,255,255)" width="24" x="376" y="296"/>
-                <path d="M 376 296 L 400 296" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 400 296 L 400 368" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 400 368 L 376 368" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 376 368 L 376 296" fill="none" stroke="rgb(0,0,0)"/>
-                <g transform="rotate(270,376,368)">
-                    <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="19" x="412.5" y="386">
-                        RST
-                    </text>
-                </g>
-                <rect fill="rgb(255,255,255)" height="72" stroke="rgb(255,255,255)" width="24" x="400" y="296"/>
-                <path d="M 400 296 L 424 296" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 424 296 L 424 368" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 424 368 L 400 368" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 400 368 L 400 296" fill="none" stroke="rgb(0,0,0)"/>
-                <g transform="rotate(270,400,368)">
-                    <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="19" x="436.5" y="386">
-                        SYN
-                    </text>
-                </g>
-                <rect fill="rgb(255,255,255)" height="72" stroke="rgb(255,255,255)" width="24" x="424" y="296"/>
-                <path d="M 424 296 L 448 296" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 448 296 L 448 368" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 448 368 L 424 368" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 424 368 L 424 296" fill="none" stroke="rgb(0,0,0)"/>
-                <g transform="rotate(270,424,368)">
-                    <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="19" x="460.5" y="386">
-                        FIN
-                    </text>
-                </g>
-                <rect fill="rgb(255,255,255)" height="72" stroke="rgb(255,255,255)" width="384" x="448" y="296"/>
-                <path d="M 448 296 L 832 296" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 832 296 L 832 368" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 832 368 L 448 368" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 448 368 L 448 296" fill="none" stroke="rgb(0,0,0)"/>
-                <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="37" x="640.5" y="338">
-                    Window
-                </text>
-                <rect fill="rgb(255,255,255)" height="72" stroke="rgb(255,255,255)" width="384" x="64" y="368"/>
-                <path d="M 64 368 L 448 368" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 448 368 L 448 440" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 448 440 L 64 440" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 64 440 L 64 368" fill="none" stroke="rgb(0,0,0)"/>
-                <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="49" x="256.5" y="410">
-                    Checksum
-                </text>
-                <rect fill="rgb(255,255,255)" height="72" stroke="rgb(255,255,255)" width="384" x="448" y="368"/>
-                <path d="M 448 368 L 832 368" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 832 368 L 832 440" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 832 440 L 448 440" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 448 440 L 448 368" fill="none" stroke="rgb(0,0,0)"/>
-                <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="85" x="640.5" y="410">
-                    Urgent Pointer
-                </text>
-                <rect fill="rgb(255,255,255)" height="72" stroke="rgb(255,255,255)" width="768" x="64" y="440"/>
-                <path d="M 64 440 L 832 440" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 832 440 L 832 512" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 832 512 L 64 512" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 64 512 L 64 440" fill="none" stroke="rgb(0,0,0)"/>
-                <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="128" x="448.0" y="482">
-                    (Options and Padding)
-                </text>
-                <rect fill="rgb(255,255,255)" height="216" stroke="rgb(255,255,255)" width="768" x="64" y="512"/>
-                <path d="M 64 512 L 832 512" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 832 512 L 832 728" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 832 728 L 64 728" fill="none" stroke="rgb(0,0,0)"/>
-                <path d="M 64 728 L 64 512" fill="none" stroke="rgb(0,0,0)"/>
-                <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="25" x="448.5" y="626">
-                    data
-                </text>
-            </svg>
+                <rect fill="rgb(255,255,255)" height="72" stroke="rgb(255,255,255)" width="384" x="448" y="296" />
+                <path d="M 448 296 L 832 296" fill="none" stroke="rgb(0,0,0)" />
+                <path d="M 832 296 L 832 368" fill="none" stroke="rgb(0,0,0)" />
+                <path d="M 832 368 L 448 368" fill="none" stroke="rgb(0,0,0)" />
+                <path d="M 448 368 L 448 296" fill="none" stroke="rgb(0,0,0)" />
+                <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="45" x="640.5" y="338">Window</text>
+                <rect fill="rgb(255,255,255)" height="72" stroke="rgb(255,255,255)" width="384" x="64" y="368" />
+                <path d="M 64 368 L 448 368" fill="none" stroke="rgb(0,0,0)" />
+                <path d="M 448 368 L 448 440" fill="none" stroke="rgb(0,0,0)" />
+                <path d="M 448 440 L 64 440" fill="none" stroke="rgb(0,0,0)" />
+                <path d="M 64 440 L 64 368" fill="none" stroke="rgb(0,0,0)" />
+                <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="59" x="256.5" y="410">Checksum</text>
+                <rect fill="rgb(255,255,255)" height="72" stroke="rgb(255,255,255)" width="384" x="448" y="368" />
+                <path d="M 448 368 L 832 368" fill="none" stroke="rgb(0,0,0)" />
+                <path d="M 832 368 L 832 440" fill="none" stroke="rgb(0,0,0)" />
+                <path d="M 832 440 L 448 440" fill="none" stroke="rgb(0,0,0)" />
+                <path d="M 448 440 L 448 368" fill="none" stroke="rgb(0,0,0)" />
+                <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="84" x="640.0" y="411">Urgent Pointer</text>
+                <rect fill="rgb(255,255,255)" height="72" stroke="rgb(255,255,255)" width="768" x="64" y="440" />
+                <path d="M 64 440 L 832 440" fill="none" stroke="rgb(0,0,0)" />
+                <path d="M 832 440 L 832 512" fill="none" stroke="rgb(0,0,0)" />
+                <path d="M 832 512 L 64 512" fill="none" stroke="rgb(0,0,0)" />
+                <path d="M 64 512 L 64 440" fill="none" stroke="rgb(0,0,0)" />
+                <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="125" x="448.5" y="483">(Options and Padding)</text>
+                <rect fill="rgb(255,255,255)" height="216" stroke="rgb(255,255,255)" width="768" x="64" y="512" />
+                <path d="M 64 512 L 832 512" fill="none" stroke="rgb(0,0,0)" />
+                <path d="M 832 512 L 832 728" fill="none" stroke="rgb(0,0,0)" />
+                <path d="M 832 728 L 64 728" fill="none" stroke="rgb(0,0,0)" />
+                <path d="M 64 728 L 64 512" fill="none" stroke="rgb(0,0,0)" />
+                <text fill="rgb(0,0,0)" font-family="sans-serif" font-size="11" font-style="normal" font-weight="normal" text-anchor="middle" textLength="25" x="448.5" y="626">data</text>
+            </svg>                  
         </div>
 
         <h3 id="rackdiag" class="title is-3">Rack diagram<a class="anchor-link" href="#rackdiag">#</a></h3>

--- a/js/main.js
+++ b/js/main.js
@@ -940,7 +940,9 @@ document.addEventListener('DOMContentLoaded', function () {
             '  32-63: Sequence Number;\n' +
             '  64-95: Acknowledgment Number;\n' +
             '  96-99: Data Offset;\n' +
-            '  100-105: Reserved;\n' +
+            '  100-103: Reserved;\n' +
+            '  104: CWR [rotate = 270];\n' +
+            '  105: ECE [rotate = 270];\n' +
             '  106: URG [rotate = 270];\n' +
             '  107: ACK [rotate = 270];\n' +
             '  108: PSH [rotate = 270];\n' +


### PR DESCRIPTION
Hi there!

I noticed that PacketDiag example uses TCP packet structure for demonstration.
So, I decided to update that with missing `CWR` and `ECE` flags.

Before:
![Updated TCP Packet](https://kroki.io/packetdiag/svg/eNptkU9Pg0AQxe9-ijnqYRN2QSgYD6bGPzFpCW1jTGPMyk5hQ9mtsMjB-N0dIGk8cH2_mXkzb04yr9ApLQv4uQDI7bHXypVwC764IcFYhR8l6qJ0pEWkkegxfp3AxnZNjpDaxg2VPGQ-T-AeW6eNdNqaM_IFC31qwK8ODbWsuvoTm4GEAYtp1F1eGdsfURU1GvePxyGLYxoqnYT14dDiZOXRBh71Zdhi841qEsMEdtkj7BvrpENaV0Te-4Qi8li-zKJFAunmaRaRc7bZziHu0Tlvq1lEITw8zyPBuKBVXrVRth8lsWA8oGyWJeZV29WjGAQUMJnvmmKII7XauCkPHtLlMTlcrk9DxC1IoyCVSmlTXI0VsWBC0EQ1ZLanh56_59MWv39OCoi9)

After:
![Updated TCP Packet](https://kroki.io/packetdiag/svg/eNptkstOwzAQRfd8xSxhYSl2QtoEsUChPITURilVhSqETDxNrLZ2SRy6QPw7k0SqWHh7zzyu7_goyx06pWUFPxcApd2ftHI13EIobkgwVuFHjbqqHWkT0kgMGL9OYWm7pkTIbeP6Sh6zkKdwj63TRjptzRmFgsUhNeBXh4Za5t3hE5uexBFLaNRduTP2tEdVHdC4fzyJWZLQUOkkLLbbFsdVATkIaGKBLTbfqEYxSiFbF7BprJMOya6YBO8joh2zbOZFcQqr4tGLJuQse_GiaQr58smLyG-xfPUhHlAIb3Mvougenv1IMC7IylobZU-DJKaMR_T-rMZy13aHQYwiOgstXzVVH2JutXFjijymvBLacLk49odpQRoFuVRKm-pqqEgEE4Imqj7pDX2D881DcvH7B-DBllc=)

References:
* https://datatracker.ietf.org/doc/html/rfc9293#name-header-format
* https://en.wikipedia.org/wiki/Transmission_Control_Protocol#TCP_segment_structure